### PR TITLE
Add @SerializeOnly & @DeserializeOnly annotation + adapters

### DIFF
--- a/src/integrationTest/java/com/serjltt/moshi/adapters/DeserializeOnlyAutoValueTest.java
+++ b/src/integrationTest/java/com/serjltt/moshi/adapters/DeserializeOnlyAutoValueTest.java
@@ -1,0 +1,40 @@
+package com.serjltt.moshi.adapters;
+
+import com.google.auto.value.AutoValue;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import java.io.IOException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class DeserializeOnlyAutoValueTest {
+  private final Moshi moshi = new Moshi.Builder()
+      .add(DeserializeOnlyJsonAdapter.FACTORY)
+      .add(DataFactories.create())
+      .build();
+
+  @Test public void serialize() {
+    final String json = AutoValueClass.jsonAdapter(moshi)
+        .toJson(new AutoValue_DeserializeOnlyAutoValueTest_AutoValueClass(1, 2));
+    assertThat(json).isEqualTo("{\"foo\":1}");
+  }
+
+  @Test public void deserialize() throws IOException {
+    final AutoValueClass autoValueClass =
+        AutoValueClass.jsonAdapter(moshi).fromJson("{\"foo\": 1,\"bar\": 2}");
+
+    assertThat(autoValueClass.foo()).isEqualTo(1);
+    assertThat(autoValueClass.bar()).isEqualTo(2);
+  }
+
+  @AutoValue abstract static class AutoValueClass {
+    public static JsonAdapter<AutoValueClass> jsonAdapter(Moshi moshi) {
+      return new AutoValue_DeserializeOnlyAutoValueTest_AutoValueClass.MoshiJsonAdapter(moshi);
+    }
+
+    abstract Integer foo();
+
+    @DeserializeOnly abstract Integer bar();
+  }
+}

--- a/src/integrationTest/java/com/serjltt/moshi/adapters/Nullable.java
+++ b/src/integrationTest/java/com/serjltt/moshi/adapters/Nullable.java
@@ -1,0 +1,5 @@
+package com.serjltt.moshi.adapters;
+
+/** For testing purposes. */
+public @interface Nullable {
+}

--- a/src/integrationTest/java/com/serjltt/moshi/adapters/SerializeOnlyAutoValueTest.java
+++ b/src/integrationTest/java/com/serjltt/moshi/adapters/SerializeOnlyAutoValueTest.java
@@ -1,0 +1,40 @@
+package com.serjltt.moshi.adapters;
+
+import com.google.auto.value.AutoValue;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import java.io.IOException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class SerializeOnlyAutoValueTest {
+  private final Moshi moshi = new Moshi.Builder()
+      .add(SerializeOnlyJsonAdapter.FACTORY)
+      .add(DataFactories.create())
+      .build();
+
+  @Test public void serialize() {
+    final String json = AutoValueClass.jsonAdapter(moshi)
+        .toJson(new AutoValue_SerializeOnlyAutoValueTest_AutoValueClass(1, 2));
+    assertThat(json).isEqualTo("{\"foo\":1,\"bar\":2}");
+  }
+
+  @Test public void deserialize() throws IOException {
+    final AutoValueClass autoValueClass =
+        AutoValueClass.jsonAdapter(moshi).fromJson("{\"foo\": 1,\"bar\": 2}");
+
+    assertThat(autoValueClass.foo()).isEqualTo(1);
+    assertThat(autoValueClass.bar()).isNull();
+  }
+
+  @AutoValue abstract static class AutoValueClass {
+    public static JsonAdapter<AutoValueClass> jsonAdapter(Moshi moshi) {
+      return new AutoValue_SerializeOnlyAutoValueTest_AutoValueClass.MoshiJsonAdapter(moshi);
+    }
+
+    abstract Integer foo();
+
+    @SerializeOnly @Nullable abstract Integer bar();
+  }
+}

--- a/src/main/java/com/serjltt/moshi/adapters/DeserializeOnly.java
+++ b/src/main/java/com/serjltt/moshi/adapters/DeserializeOnly.java
@@ -1,10 +1,24 @@
 package com.serjltt.moshi.adapters;
 
 import com.squareup.moshi.JsonQualifier;
+import com.squareup.moshi.Moshi;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+/**
+ * Indicates that the annotated field may only be deserialized.
+ *
+ * <p>To leverage from {@linkplain DeserializeOnly} the
+ * {@linkplain DeserializeOnlyJsonAdapter#FACTORY} must be added to a
+ * {@linkplain Moshi Moshi instance}:
+ *
+ * <pre><code>
+ *   Moshi moshi = new Moshi.Builder()
+ *      .add(DeserializeOnlyJsonAdapter.FACTORY)
+ *      .build();
+ * </code></pre>
+ */
 @Documented
 @JsonQualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/com/serjltt/moshi/adapters/DeserializeOnly.java
+++ b/src/main/java/com/serjltt/moshi/adapters/DeserializeOnly.java
@@ -3,8 +3,10 @@ package com.serjltt.moshi.adapters;
 import com.squareup.moshi.JsonQualifier;
 import com.squareup.moshi.Moshi;
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Indicates that the annotated field may only be deserialized.
@@ -22,5 +24,6 @@ import java.lang.annotation.RetentionPolicy;
 @Documented
 @JsonQualifier
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.METHOD })
 public @interface DeserializeOnly {
 }

--- a/src/main/java/com/serjltt/moshi/adapters/DeserializeOnly.java
+++ b/src/main/java/com/serjltt/moshi/adapters/DeserializeOnly.java
@@ -1,0 +1,12 @@
+package com.serjltt.moshi.adapters;
+
+import com.squareup.moshi.JsonQualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Documented
+@JsonQualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DeserializeOnly {
+}

--- a/src/main/java/com/serjltt/moshi/adapters/DeserializeOnlyJsonAdapter.java
+++ b/src/main/java/com/serjltt/moshi/adapters/DeserializeOnlyJsonAdapter.java
@@ -1,0 +1,48 @@
+package com.serjltt.moshi.adapters;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static com.serjltt.moshi.adapters.Util.findAnnotation;
+
+public final class DeserializeOnlyJsonAdapter<T> extends JsonAdapter<T> {
+  public static final JsonAdapter.Factory FACTORY = new JsonAdapter.Factory() {
+    @Override public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations,
+        Moshi moshi) {
+      Annotation annotation = findAnnotation(annotations, DeserializeOnly.class);
+      if (annotation == null) return null;
+
+      // Clone the set and remove the annotation so that we can pass the remaining set to moshi.
+      Set<? extends Annotation> reducedAnnotations = new LinkedHashSet<>(annotations);
+      reducedAnnotations.remove(annotation);
+
+      return new DeserializeOnlyJsonAdapter<>(moshi.adapter(type, reducedAnnotations));
+    }
+  };
+
+  private final JsonAdapter<T> delegate;
+
+  DeserializeOnlyJsonAdapter(JsonAdapter<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public T fromJson(JsonReader reader) throws IOException {
+    return delegate.fromJson(reader);
+  }
+
+  @Override public void toJson(JsonWriter writer, T value) throws IOException {
+    // We'll need to consume this property otherwise we'll get an IllegalArgumentException.
+    delegate.toJson(writer, null);
+  }
+
+  @Override public String toString() {
+    return delegate + ".deserializeOnly()";
+  }
+}

--- a/src/main/java/com/serjltt/moshi/adapters/FirstElement.java
+++ b/src/main/java/com/serjltt/moshi/adapters/FirstElement.java
@@ -18,8 +18,10 @@ package com.serjltt.moshi.adapters;
 import com.squareup.moshi.JsonQualifier;
 import com.squareup.moshi.Moshi;
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Indicates that the annotated type/field is <strong>expected</strong> to be the first element of a
@@ -57,5 +59,6 @@ import java.lang.annotation.RetentionPolicy;
 @Documented
 @JsonQualifier
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.METHOD })
 public @interface FirstElement {
 }

--- a/src/main/java/com/serjltt/moshi/adapters/SerializeOnly.java
+++ b/src/main/java/com/serjltt/moshi/adapters/SerializeOnly.java
@@ -1,0 +1,12 @@
+package com.serjltt.moshi.adapters;
+
+import com.squareup.moshi.JsonQualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Documented
+@JsonQualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SerializeOnly {
+}

--- a/src/main/java/com/serjltt/moshi/adapters/SerializeOnly.java
+++ b/src/main/java/com/serjltt/moshi/adapters/SerializeOnly.java
@@ -1,10 +1,24 @@
 package com.serjltt.moshi.adapters;
 
 import com.squareup.moshi.JsonQualifier;
+import com.squareup.moshi.Moshi;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+/**
+ * Indicates that the annotated field may only be serialized.
+ *
+ * <p>To leverage from {@linkplain SerializeOnly} the
+ * {@linkplain SerializeOnlyJsonAdapter#FACTORY} must be added to a
+ * {@linkplain Moshi Moshi instance}:
+ *
+ * <pre><code>
+ *   Moshi moshi = new Moshi.Builder()
+ *      .add(SerializeOnlyJsonAdapter.FACTORY)
+ *      .build();
+ * </code></pre>
+ */
 @Documented
 @JsonQualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyJsonAdapter.java
+++ b/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyJsonAdapter.java
@@ -1,0 +1,48 @@
+package com.serjltt.moshi.adapters;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static com.serjltt.moshi.adapters.Util.findAnnotation;
+
+public final class SerializeOnlyJsonAdapter<T> extends JsonAdapter<T> {
+  public static final JsonAdapter.Factory FACTORY = new JsonAdapter.Factory() {
+    @Override public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations,
+        Moshi moshi) {
+      Annotation annotation = findAnnotation(annotations, SerializeOnly.class);
+      if (annotation == null) return null;
+
+      // Clone the set and remove the annotation so that we can pass the remaining set to moshi.
+      Set<? extends Annotation> reducedAnnotations = new LinkedHashSet<>(annotations);
+      reducedAnnotations.remove(annotation);
+
+      return new SerializeOnlyJsonAdapter<>(moshi.adapter(type, reducedAnnotations));
+    }
+  };
+
+  private final JsonAdapter<T> delegate;
+
+  SerializeOnlyJsonAdapter(JsonAdapter<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public T fromJson(JsonReader reader) throws IOException {
+    reader.skipValue();
+    return null;
+  }
+
+  @Override public void toJson(JsonWriter writer, T value) throws IOException {
+    delegate.toJson(writer, value);
+  }
+
+  @Override public String toString() {
+    return delegate + ".serializeOnly()";
+  }
+}

--- a/src/unitTest/java/com/serjltt/moshi/adapters/DeserializeOnlyJsonAdapterTest.java
+++ b/src/unitTest/java/com/serjltt/moshi/adapters/DeserializeOnlyJsonAdapterTest.java
@@ -1,0 +1,54 @@
+package com.serjltt.moshi.adapters;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class DeserializeOnlyJsonAdapterTest {
+  // Lazy adapters work only within the context of moshi.
+  private final Moshi moshi = new Moshi.Builder()
+      .add(DeserializeOnlyJsonAdapter.FACTORY)
+      .add(new Custom.CustomAdapter()) // We need to check that other annotations are not lost.
+      .build();
+
+  @Test public void deserializeOnly() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\"data\": \"test\"}");
+    assertThat(fromJson.data).isEqualTo("test");
+
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+  }
+
+  @Test public void factoryMaintainsOtherAnnotations() throws Exception {
+    JsonAdapter<Data2> adapter = moshi.adapter(Data2.class);
+
+    Data2 fromJson = adapter.fromJson("{\"data\": \"test\"}");
+    assertThat(fromJson.data).isEqualTo("testCustom");
+
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+  }
+
+  @Test public void toStringReflectsInnerAdapter() throws Exception {
+    JsonAdapter<String> adapter = moshi.adapter(String.class, Collections.singleton(
+        new DeserializeOnly() {
+          @Override public Class<? extends Annotation> annotationType() {
+            return DeserializeOnly.class;
+          }
+        }));
+
+    assertThat(adapter.toString()).isEqualTo("JsonAdapter(String).nullSafe().deserializeOnly()");
+  }
+
+  private static class Data1 {
+    @DeserializeOnly String data;
+  }
+
+  private static class Data2 {
+    @DeserializeOnly @Custom String data;
+  }
+}

--- a/src/unitTest/java/com/serjltt/moshi/adapters/SerializeOnlyJsonAdapterTest.java
+++ b/src/unitTest/java/com/serjltt/moshi/adapters/SerializeOnlyJsonAdapterTest.java
@@ -1,0 +1,63 @@
+package com.serjltt.moshi.adapters;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class SerializeOnlyJsonAdapterTest {
+  // Lazy adapters work only within the context of moshi.
+  private final Moshi moshi = new Moshi.Builder()
+      .add(SerializeOnlyJsonAdapter.FACTORY)
+      .add(SerializeNullsJsonAdapter.FACTORY)
+      .add(new Custom.CustomAdapter()) // We need to check that other annotations are not lost.
+      .build();
+
+  @Test public void serializeOnly() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\"data\": \"test\"}");
+    assertThat(fromJson.data).isNull();
+
+    fromJson.data = "1234";
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"data\":\"1234\"}");
+  }
+
+  @Test public void factoryMaintainsOtherAnnotations() throws Exception {
+    JsonAdapter<Data2> adapter = moshi.adapter(Data2.class);
+
+    Data2 fromJson = adapter.fromJson("{\"data\": \"test\"}");
+    assertThat(fromJson.data).isNull();
+
+    fromJson.data = "1234Custom";
+    String toJson = adapter.toJson(fromJson);
+    assertThat(toJson).isEqualTo("{\"data\":\"1234\"}");
+
+    Data2 data = new Data2();
+    data.data = null;
+    toJson = adapter.toJson(data);
+    assertThat(toJson).isEqualTo("{\"data\":null}");
+  }
+
+  @Test public void toStringReflectsInnerAdapter() throws Exception {
+    JsonAdapter<String> adapter =
+        moshi.adapter(String.class, Collections.singleton(new SerializeOnly() {
+          @Override public Class<? extends Annotation> annotationType() {
+            return SerializeOnly.class;
+          }
+        }));
+
+    assertThat(adapter.toString()).isEqualTo("JsonAdapter(String).nullSafe().serializeOnly()");
+  }
+
+  private static class Data1 {
+    @SerializeOnly String data;
+  }
+
+  private static class Data2 {
+    @Custom @SerializeOnly @SerializeNulls String data;
+  }
+}


### PR DESCRIPTION
Few things are still missing:

- [x] integration tests with Auto Value
- [x] ~~integration tests with Retrofit?~~ (these annotations are intended for use inside an object, that is tested by there respective tests)
- [x] fix SerializeOnlyJsonAdapterTest#factoryMaintainsOtherAnnotations test (do you have any idea for this one?)
- [x] documentation on how to use them

Fixes #17 