### PR TITLE
Introduce FallbackEnum annotation.

### DIFF
--- a/src/main/java/com/serjltt/moshi/adapters/FallbackEnum.java
+++ b/src/main/java/com/serjltt/moshi/adapters/FallbackEnum.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Serj Lotutovici
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.serjltt.moshi.adapters;
+
+import com.squareup.moshi.Moshi;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated enum has a fallback value. The fallback must be set via
+ * {@link #name()}. If no enum constant with the provided name is declared in the annotated
+ * enum type an {@linkplain AssertionError assertion error} will be thrown.
+ *
+ * <p>To leverage from {@linkplain FallbackEnum} the {@linkplain FallbackEnumJsonAdapter#FACTORY}
+ * must be added to a {@linkplain Moshi moshi instance}:
+ *
+ * <pre><code>
+ *   Moshi moshi = new Moshi.Builder()
+ *      .add(FallbackEnumJsonAdapter.FACTORY)
+ *      .build();
+ * </code></pre>
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface FallbackEnum {
+  String name();
+}

--- a/src/main/java/com/serjltt/moshi/adapters/FallbackEnumJsonAdapter.java
+++ b/src/main/java/com/serjltt/moshi/adapters/FallbackEnumJsonAdapter.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2016 Serj Lotutovici
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.serjltt.moshi.adapters;
+
+import com.squareup.moshi.Json;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * {@linkplain JsonAdapter} that fallbacks to a default enum constant declared in the enum type
+ * annotated with {@linkplain FallbackEnum}.
+ */
+public final class FallbackEnumJsonAdapter<T extends Enum<T>> extends JsonAdapter<T> {
+  public static final JsonAdapter.Factory FACTORY = new JsonAdapter.Factory() {
+    @Override public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations,
+        Moshi moshi) {
+      if (!annotations.isEmpty()) return null;
+
+      Class<?> rawType = Types.getRawType(type);
+      if (rawType.isEnum()) {
+        FallbackEnum annotation = rawType.getAnnotation(FallbackEnum.class);
+        if (annotation == null) return null;
+
+        //noinspection unchecked
+        return new FallbackEnumJsonAdapter<>((Class<? extends Enum>) rawType, annotation.name())
+            .nullSafe();
+      }
+
+      return null;
+    }
+  };
+
+  private final Class<T> enumType;
+  private final T fallbackConstant;
+  private final Map<String, T> nameConstantMap;
+  private final String[] nameStrings;
+
+  FallbackEnumJsonAdapter(Class<T> enumType, String fallback) {
+    this.enumType = enumType;
+
+    try {
+      int fallbackConstantIndex = -1;
+      T[] constants = enumType.getEnumConstants();
+      nameConstantMap = new LinkedHashMap<>();
+      nameStrings = new String[constants.length];
+
+      for (int i = 0; i < constants.length; i++) {
+        T constant = constants[i];
+        Json annotation = enumType.getField(constant.name()).getAnnotation(Json.class);
+        String name = annotation != null ? annotation.name() : constant.name();
+        nameConstantMap.put(name, constant);
+        nameStrings[i] = name;
+
+        if (fallback.equals(constant.name())) {
+          fallbackConstantIndex = i;
+        }
+      }
+
+      if (fallbackConstantIndex != -1) {
+        fallbackConstant = constants[fallbackConstantIndex];
+      } else {
+        throw new NoSuchFieldException("Filed \"" + fallback + "\" is not declared.");
+      }
+    } catch (NoSuchFieldException e) {
+      throw new AssertionError("Missing field in " + enumType.getName(), e);
+    }
+  }
+
+  @Override public T fromJson(JsonReader reader) throws IOException {
+    String name = reader.nextString();
+    T constant = nameConstantMap.get(name);
+    if (constant != null) return constant;
+    return fallbackConstant;
+  }
+
+  @Override public void toJson(JsonWriter writer, T value) throws IOException {
+    writer.value(nameStrings[value.ordinal()]);
+  }
+
+  @Override public String toString() {
+    return "JsonAdapter(" + enumType.getName() + ").fallbackEnum(" + fallbackConstant + ")";
+  }
+}

--- a/src/unitTest/java/com/serjltt/moshi/adapters/FallbackEnumJsonAdapterTest.java
+++ b/src/unitTest/java/com/serjltt/moshi/adapters/FallbackEnumJsonAdapterTest.java
@@ -98,12 +98,12 @@ public final class FallbackEnumJsonAdapterTest {
   @FallbackEnum(name = "UNKNOWN") enum Roshambo {
     ROCK,
     PAPER,
-    @Json(name = "scr")SCISSORS,
+    @Json(name = "scr") SCISSORS,
     UNKNOWN
   }
 
   @FallbackEnum(name = "UNK") enum Value {
-    @SuppressWarnings("unused")UNKNOWN
+    @SuppressWarnings("unused") UNKNOWN
   }
 
   enum Regular {

--- a/src/unitTest/java/com/serjltt/moshi/adapters/FallbackEnumJsonAdapterTest.java
+++ b/src/unitTest/java/com/serjltt/moshi/adapters/FallbackEnumJsonAdapterTest.java
@@ -20,6 +20,8 @@ import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonDataException;
 import com.squareup.moshi.Moshi;
+import java.lang.annotation.Annotation;
+import java.util.Collections;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,6 +83,16 @@ public final class FallbackEnumJsonAdapterTest {
       assertThat(expected).hasMessage(
           "Expected one of [ONE] but was TWO at path $");
     }
+  }
+
+  @Test public void factoryIgnoresUnsupportedTypes() throws Exception {
+    JsonAdapter<?> adapter1 = FallbackEnumJsonAdapter.FACTORY
+        .create(String.class, Collections.<Annotation>emptySet(), moshi);
+    assertThat(adapter1).isNull();
+
+    JsonAdapter<?> adapter2 = FallbackEnumJsonAdapter.FACTORY
+        .create(Roshambo.class, Collections.singleton(Wrapped.Factory.create("")), moshi);
+    assertThat(adapter2).isNull();
   }
 
   @FallbackEnum(name = "UNKNOWN") enum Roshambo {

--- a/src/unitTest/java/com/serjltt/moshi/adapters/FallbackEnumJsonAdapterTest.java
+++ b/src/unitTest/java/com/serjltt/moshi/adapters/FallbackEnumJsonAdapterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 Serj Lotutovici
+ * Copyright (C) 2014 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.serjltt.moshi.adapters;
+
+import com.squareup.moshi.Json;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.Moshi;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public final class FallbackEnumJsonAdapterTest {
+  // Lazy adapters work only within the context of moshi.
+  private final Moshi moshi = new Moshi.Builder()
+      .add(FallbackEnumJsonAdapter.FACTORY)
+      .build();
+
+  @Test public void asRegularEnumAdapter() throws Exception {
+    JsonAdapter<Roshambo> adapter = moshi.adapter(Roshambo.class).lenient();
+    assertThat(adapter.fromJson("\"ROCK\"")).isEqualTo(Roshambo.ROCK);
+    assertThat(adapter.toJson(Roshambo.PAPER)).isEqualTo("\"PAPER\"");
+    // Check annotated value
+    assertThat(adapter.fromJson("\"scr\"")).isEqualTo(Roshambo.SCISSORS);
+    assertThat(adapter.toJson(Roshambo.SCISSORS)).isEqualTo("\"scr\"");
+  }
+
+  @Test public void fallbackEnum() throws Exception {
+    JsonAdapter<Roshambo> adapter = moshi.adapter(Roshambo.class).lenient();
+    assertThat(adapter.fromJson("\"SPOCK\"")).isEqualTo(Roshambo.UNKNOWN);
+  }
+
+  @Test public void nullEnum() throws Exception {
+    JsonAdapter<Roshambo> adapter = moshi.adapter(Roshambo.class).lenient();
+    assertThat(adapter.fromJson("null")).isNull();
+    assertThat(adapter.toJson(null)).isEqualTo("null");
+  }
+
+  @Test public void throwsOnInvalidFallback() throws Exception {
+    try {
+      moshi.adapter(Value.class);
+      fail();
+    } catch (Error ex) {
+      assertThat(ex).hasMessage("Missing field in "
+          + "com.serjltt.moshi.adapters.FallbackEnumJsonAdapterTest$Value");
+      assertThat(ex.getCause()).hasMessage("Filed \"UNK\" is not declared.");
+    }
+  }
+
+  @Test public void toStringReflectsInnerAdapter() throws Exception {
+    JsonAdapter<Roshambo> adapter = moshi.adapter(Roshambo.class);
+
+    assertThat(adapter.toString()).isEqualTo(
+        "JsonAdapter(com.serjltt.moshi.adapters.FallbackEnumJsonAdapterTest$Roshambo)"
+            + ".fallbackEnum(UNKNOWN).nullSafe()");
+  }
+
+  @Test public void ignoresUnannotatedEnums() throws Exception {
+    JsonAdapter<Regular> adapter = moshi.adapter(Regular.class).lenient();
+    assertThat(adapter.fromJson("\"ONE\"")).isEqualTo(Regular.ONE);
+
+    try {
+      adapter.fromJson("\"TWO\"");
+      fail();
+    } catch (JsonDataException expected) {
+      assertThat(expected).hasMessage(
+          "Expected one of [ONE] but was TWO at path $");
+    }
+  }
+
+  @FallbackEnum(name = "UNKNOWN") enum Roshambo {
+    ROCK,
+    PAPER,
+    @Json(name = "scr")SCISSORS,
+    UNKNOWN
+  }
+
+  @FallbackEnum(name = "UNK") enum Value {
+    @SuppressWarnings("unused")UNKNOWN
+  }
+
+  enum Regular {
+    ONE
+  }
+}


### PR DESCRIPTION
This forks moshi's way of parsing enums adding the fallback functional. The factory is designed in such a way so that only annotated enums are handled.
This has two design flaws:
- `FallbackEnum#name()` accepts a string, which means no name safety (unless the ide in use supports such refactoring) 
- Moshi under the hood uses `JsonReader.Options` which is faster, but is not a public api at the moment (will try to push for that in the upcoming days).