### PR TITLE
FirstElement now relies on ElementAt adapter.

### DIFF
--- a/src/main/java/com/serjltt/moshi/adapters/ElementAtJsonAdapter.java
+++ b/src/main/java/com/serjltt/moshi/adapters/ElementAtJsonAdapter.java
@@ -46,26 +46,26 @@ public final class ElementAtJsonAdapter<T> extends JsonAdapter<T> {
     }
   };
 
-  private final JsonAdapter<List<T>> adapter;
+  private final JsonAdapter<List<T>> delegate;
   private final int index;
 
   ElementAtJsonAdapter(Type type, Moshi moshi, int index) {
     Type listType = Types.newParameterizedType(List.class, type);
-    adapter = moshi.adapter(listType);
+    delegate = moshi.adapter(listType);
     this.index = index;
   }
 
   @Override public T fromJson(JsonReader reader) throws IOException {
-    List<T> fromJson = adapter.fromJson(reader);
+    List<T> fromJson = delegate.fromJson(reader);
     if (fromJson != null && index < fromJson.size()) return fromJson.get(index);
     return null;
   }
 
   @Override public void toJson(JsonWriter writer, T value) throws IOException {
-    adapter.toJson(writer, Collections.singletonList(value));
+    delegate.toJson(writer, Collections.singletonList(value));
   }
 
   @Override public String toString() {
-    return adapter + ".elementAt(" + index + ")";
+    return delegate + ".elementAt(" + index + ")";
   }
 }

--- a/src/main/java/com/serjltt/moshi/adapters/FirstElementJsonAdapter.java
+++ b/src/main/java/com/serjltt/moshi/adapters/FirstElementJsonAdapter.java
@@ -16,15 +16,9 @@
 package com.serjltt.moshi.adapters;
 
 import com.squareup.moshi.JsonAdapter;
-import com.squareup.moshi.JsonReader;
-import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
-import com.squareup.moshi.Types;
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 import static com.serjltt.moshi.adapters.Util.hasAnnotation;
@@ -33,35 +27,18 @@ import static com.serjltt.moshi.adapters.Util.hasAnnotation;
  * {@linkplain JsonAdapter} that extracts the first element of an array of (a field) type annotated
  * with {@linkplain FirstElement}.
  */
-public final class FirstElementJsonAdapter<T> extends JsonAdapter<T> {
+public final class FirstElementJsonAdapter {
   public static final JsonAdapter.Factory FACTORY = new JsonAdapter.Factory() {
     @Override public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations,
         Moshi moshi) {
       if (hasAnnotation(annotations, FirstElement.class) && annotations.size() == 1) {
-        return new FirstElementJsonAdapter<>(type, moshi);
+        return new ElementAtJsonAdapter<>(type, moshi, 0);
       }
       return null;
     }
   };
 
-  private final JsonAdapter<List<T>> adapter;
-
-  FirstElementJsonAdapter(Type type, Moshi moshi) {
-    Type listType = Types.newParameterizedType(List.class, type);
-    adapter = moshi.adapter(listType);
-  }
-
-  @Override public T fromJson(JsonReader reader) throws IOException {
-    List<T> fromJson = adapter.fromJson(reader);
-    if (fromJson != null && !fromJson.isEmpty()) return fromJson.get(0);
-    return null;
-  }
-
-  @Override public void toJson(JsonWriter writer, T value) throws IOException {
-    adapter.toJson(writer, Collections.singletonList(value));
-  }
-
-  @Override public String toString() {
-    return adapter + ".first()";
+  private FirstElementJsonAdapter() {
+    throw new AssertionError("No instances.");
   }
 }

--- a/src/unitTest/java/com/serjltt/moshi/adapters/FirstElementJsonAdapterTest.java
+++ b/src/unitTest/java/com/serjltt/moshi/adapters/FirstElementJsonAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package com.serjltt.moshi.adapters;
 
+import com.pushtorefresh.private_constructor_checker.PrivateConstructorChecker;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonDataException;
@@ -132,7 +133,15 @@ public final class FirstElementJsonAdapterTest {
         }));
 
     assertThat(adapter.toString())
-        .isEqualTo("JsonAdapter(String).nullSafe().collection().nullSafe().first()");
+        .isEqualTo("JsonAdapter(String).nullSafe().collection().nullSafe().elementAt(0)");
+  }
+
+  @Test public void firstElementJsonAdapterDoesNotAllowInstances() throws Exception {
+    PrivateConstructorChecker
+        .forClass(FirstElementJsonAdapter.class)
+        .expectedTypeOfException(AssertionError.class)
+        .expectedExceptionMessage("No instances.")
+        .check();
   }
 
   private void assertNullReturn(String string) throws IOException {


### PR DESCRIPTION
IMO we should keep `@FirstElement` for some time, but there is not need to rely on a different class since ElementAt adapter is doing this for us.