### PR TITLE
Update Moshi to 1.3.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
   ci = 'true'.equals(System.getenv('CI'))
 
   /* Dependencies */
-  moshi = 'com.squareup.moshi:moshi:1.3.0'
+  moshi = 'com.squareup.moshi:moshi:1.3.1'
 
   /* Testing */
   junit = 'junit:junit:4.12'


### PR DESCRIPTION
Not that a release for this is necessary. Just keeping track of the latest version though. Especially since there was a nasty escaping bug in 1.3.0