### PR TITLE
Add SerializeOnlyNonEmpty

### DIFF
--- a/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmpty.java
+++ b/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmpty.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.serjltt.moshi.adapters;
 
 import com.squareup.moshi.JsonQualifier;
@@ -24,15 +25,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that the annotated type/field should be serialized as {@code null} in case of a
- * empty/null value.
+ * Indicates that the annotated type/field should not be serialized in case of an
+ * empty value.
  *
- * <p>To leverage from {@linkplain SerializeNulls} the {@linkplain
- * SerializeNullsJsonAdapter#FACTORY} must be added to a {@linkplain Moshi Moshi instance}:
+ * <p>To leverage from {@linkplain SerializeOnlyNonEmpty} the {@linkplain
+ * SerializeOnlyNonEmptyJsonAdapter#FACTORY} must be added to a {@linkplain Moshi Moshi instance}:
  *
  * <pre><code>
  *   Moshi moshi = new Moshi.Builder()
- *      .add(SerializeNullsJsonAdapter.FACTORY)
+ *      .add(SerializeOnlyNonEmptyJsonAdapter.FACTORY)
  *      .build();
  * </code></pre>
  */
@@ -40,5 +41,5 @@ import java.lang.annotation.Target;
 @JsonQualifier
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.METHOD })
-public @interface SerializeNulls {
+public @interface SerializeOnlyNonEmpty {
 }

--- a/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapter.java
+++ b/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapter.java
@@ -1,0 +1,79 @@
+package com.serjltt.moshi.adapters;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.serjltt.moshi.adapters.Util.findAnnotation;
+
+/**
+ * {@linkplain JsonAdapter} that will not serialize {@code T} when the passed value is empty.
+ */
+public final class SerializeOnlyNonEmptyJsonAdapter<T> extends JsonAdapter<T> {
+  public static final JsonAdapter.Factory FACTORY = new JsonAdapter.Factory() {
+    @Override public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations,
+        Moshi moshi) {
+      Annotation annotation = findAnnotation(annotations, SerializeOnlyNonEmpty.class);
+      if (annotation == null) return null;
+
+      Class<?> rawType = Types.getRawType(type);
+
+      if (rawType.isArray() || Collection.class == rawType || Map.class == rawType) {
+        // Clone the set and remove the annotation so that we can pass the remaining set to moshi.
+        Set<? extends Annotation> reducedAnnotations = new LinkedHashSet<>(annotations);
+        reducedAnnotations.remove(annotation);
+
+        return new SerializeOnlyNonEmptyJsonAdapter<>(moshi.adapter(type, reducedAnnotations));
+      }
+
+      return null;
+    }
+  };
+
+  private final JsonAdapter<T> delegate;
+
+  SerializeOnlyNonEmptyJsonAdapter(JsonAdapter<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override public T fromJson(JsonReader reader) throws IOException {
+    return delegate.fromJson(reader);
+  }
+
+  @Override public void toJson(JsonWriter writer, T value) throws IOException {
+    if (isNotEmpty(value)) {
+      delegate.toJson(writer, value);
+    } else {
+      // We'll need to consume this property otherwise we'll get an IllegalArgumentException.
+      delegate.toJson(writer, null);
+    }
+  }
+
+  private boolean isNotEmpty(final T value) {
+    if (value instanceof Object[]) {
+      Object[] array = (Object[]) value;
+      return array.length > 0;
+    } else if (value instanceof Collection) {
+      Collection collection = (Collection) value;
+      return collection.size() > 0;
+    } else if (value instanceof Map) {
+      Map map = (Map) value;
+      return map.size() > 0;
+    }
+
+    return false;
+  }
+
+  @Override public String toString() {
+    return delegate + ".serializeOnlyNonEmpty()";
+  }
+}

--- a/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapter.java
+++ b/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapter.java
@@ -27,7 +27,7 @@ public final class SerializeOnlyNonEmptyJsonAdapter<T> extends JsonAdapter<T> {
 
       Class<?> rawType = Types.getRawType(type);
 
-      if (rawType.isArray() || Collection.class == rawType || Map.class == rawType) {
+      if (rawType.isArray() || Collection.class.isAssignableFrom(rawType) || Map.class.isAssignableFrom(rawType)) {
         // Clone the set and remove the annotation so that we can pass the remaining set to moshi.
         Set<? extends Annotation> reducedAnnotations = new LinkedHashSet<>(annotations);
         reducedAnnotations.remove(annotation);

--- a/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapter.java
+++ b/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapter.java
@@ -28,7 +28,8 @@ public final class SerializeOnlyNonEmptyJsonAdapter<T> extends JsonAdapter<T> {
 
       Class<?> rawType = Types.getRawType(type);
 
-      if (rawType.isArray() || Collection.class.isAssignableFrom(rawType) || Map.class.isAssignableFrom(rawType)) {
+      if (rawType.isArray() || Collection.class.isAssignableFrom(rawType)
+          || Map.class.isAssignableFrom(rawType)) {
         // Clone the set and remove the annotation so that we can pass the remaining set to moshi.
         Set<? extends Annotation> reducedAnnotations = new LinkedHashSet<>(annotations);
         reducedAnnotations.remove(annotation);

--- a/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapter.java
+++ b/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapter.java
@@ -68,6 +68,30 @@ public final class SerializeOnlyNonEmptyJsonAdapter<T> extends JsonAdapter<T> {
     } else if (value instanceof Map) {
       Map map = (Map) value;
       return map.size() > 0;
+    } else if (value instanceof byte[]) {
+      byte[] array = (byte[]) value;
+      return array.length > 0;
+    } else if (value instanceof char[]) {
+      char[] array = (char[]) value;
+      return array.length > 0;
+    } else if (value instanceof short[]) {
+      short[] array = (short[]) value;
+      return array.length > 0;
+    } else if (value instanceof int[]) {
+      int[] array = (int[]) value;
+      return array.length > 0;
+    } else if (value instanceof long[]) {
+      long[] array = (long[]) value;
+      return array.length > 0;
+    } else if (value instanceof float[]) {
+      float[] array = (float[]) value;
+      return array.length > 0;
+    } else if (value instanceof double[]) {
+      double[] array = (double[]) value;
+      return array.length > 0;
+    } else if (value instanceof boolean[]) {
+      boolean[] array = (boolean[]) value;
+      return array.length > 0;
     }
 
     return false;

--- a/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapter.java
+++ b/src/main/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapter.java
@@ -7,6 +7,7 @@ import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -59,39 +60,14 @@ public final class SerializeOnlyNonEmptyJsonAdapter<T> extends JsonAdapter<T> {
   }
 
   private boolean isNotEmpty(final T value) {
-    if (value instanceof Object[]) {
-      Object[] array = (Object[]) value;
-      return array.length > 0;
-    } else if (value instanceof Collection) {
+    if (value instanceof Collection) {
       Collection collection = (Collection) value;
       return collection.size() > 0;
     } else if (value instanceof Map) {
       Map map = (Map) value;
       return map.size() > 0;
-    } else if (value instanceof byte[]) {
-      byte[] array = (byte[]) value;
-      return array.length > 0;
-    } else if (value instanceof char[]) {
-      char[] array = (char[]) value;
-      return array.length > 0;
-    } else if (value instanceof short[]) {
-      short[] array = (short[]) value;
-      return array.length > 0;
-    } else if (value instanceof int[]) {
-      int[] array = (int[]) value;
-      return array.length > 0;
-    } else if (value instanceof long[]) {
-      long[] array = (long[]) value;
-      return array.length > 0;
-    } else if (value instanceof float[]) {
-      float[] array = (float[]) value;
-      return array.length > 0;
-    } else if (value instanceof double[]) {
-      double[] array = (double[]) value;
-      return array.length > 0;
-    } else if (value instanceof boolean[]) {
-      boolean[] array = (boolean[]) value;
-      return array.length > 0;
+    } else if (value != null) {
+      return Array.getLength(value) > 0;
     }
 
     return false;

--- a/src/main/java/com/serjltt/moshi/adapters/Wrapped.java
+++ b/src/main/java/com/serjltt/moshi/adapters/Wrapped.java
@@ -49,7 +49,7 @@ import java.lang.annotation.Target;
  * value {@code "OK"}.
  *
  * <p>To leverage from {@linkplain Wrapped} the {@linkplain WrappedJsonAdapter#FACTORY} must be
- * added  to a {@linkplain Moshi Moshi instance}:
+ * added to a {@linkplain Moshi Moshi instance}:
  *
  * <pre><code>
  *   Moshi moshi = new Moshi.Builder()

--- a/src/unitTest/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapterTest.java
+++ b/src/unitTest/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapterTest.java
@@ -49,7 +49,7 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
     fromJson.customArray = new CustomType[0];
     assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
 
-    fromJson.customArray = new CustomType[] { new CustomType("blub") };
+    fromJson.customArray = new CustomType[] {new CustomType("blub")};
     assertThat(adapter.toJson(fromJson)).isEqualTo("{\"customArray\":[{\"data\":\"blub\"}]}");
   }
 
@@ -64,7 +64,7 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
     fromJson.byteArray = new byte[0];
     assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
 
-    fromJson.byteArray = new byte[] { 5 };
+    fromJson.byteArray = new byte[] {5};
     assertThat(adapter.toJson(fromJson)).isEqualTo("{\"byteArray\":[5]}");
   }
 
@@ -79,7 +79,7 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
     fromJson.charArray = new char[0];
     assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
 
-    fromJson.charArray = new char[] { 65 };
+    fromJson.charArray = new char[] {65};
     assertThat(adapter.toJson(fromJson)).isEqualTo("{\"charArray\":[\"A\"]}");
   }
 
@@ -94,7 +94,7 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
     fromJson.shortArray = new short[0];
     assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
 
-    fromJson.shortArray = new short[] { 5 };
+    fromJson.shortArray = new short[] {5};
     assertThat(adapter.toJson(fromJson)).isEqualTo("{\"shortArray\":[5]}");
   }
 
@@ -109,7 +109,7 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
     fromJson.intArray = new int[0];
     assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
 
-    fromJson.intArray = new int[] { 5 };
+    fromJson.intArray = new int[] {5};
     assertThat(adapter.toJson(fromJson)).isEqualTo("{\"intArray\":[5]}");
   }
 
@@ -124,7 +124,7 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
     fromJson.longArray = new long[0];
     assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
 
-    fromJson.longArray = new long[] { 5L };
+    fromJson.longArray = new long[] {5L};
     assertThat(adapter.toJson(fromJson)).isEqualTo("{\"longArray\":[5]}");
   }
 
@@ -139,7 +139,7 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
     fromJson.floatArray = new float[0];
     assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
 
-    fromJson.floatArray = new float[] { 5f };
+    fromJson.floatArray = new float[] {5f};
     assertThat(adapter.toJson(fromJson)).isEqualTo("{\"floatArray\":[5.0]}");
   }
 
@@ -154,7 +154,7 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
     fromJson.doubleArray = new double[0];
     assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
 
-    fromJson.doubleArray = new double[] { 5f };
+    fromJson.doubleArray = new double[] {5f};
     assertThat(adapter.toJson(fromJson)).isEqualTo("{\"doubleArray\":[5.0]}");
   }
 
@@ -169,7 +169,7 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
     fromJson.booleanArray = new boolean[0];
     assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
 
-    fromJson.booleanArray = new boolean[] { false };
+    fromJson.booleanArray = new boolean[] {false};
     assertThat(adapter.toJson(fromJson)).isEqualTo("{\"booleanArray\":[false]}");
   }
 
@@ -184,7 +184,7 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
     fromJson.stringArray = new String[0];
     assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
 
-    fromJson.stringArray = new String[] { "blub" };
+    fromJson.stringArray = new String[] {"blub"};
     assertThat(adapter.toJson(fromJson)).isEqualTo("{\"stringArray\":[\"blub\"]}");
   }
 

--- a/src/unitTest/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapterTest.java
+++ b/src/unitTest/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapterTest.java
@@ -124,7 +124,7 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
         }));
 
     assertThat(adapter.toString())
-        .isEqualTo("JsonAdapter(String[]).serializeOnlyNonEmpty()");
+        .endsWith(".serializeOnlyNonEmpty()");
   }
 
   static class Data1 {

--- a/src/unitTest/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapterTest.java
+++ b/src/unitTest/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapterTest.java
@@ -53,6 +53,51 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
     assertThat(adapter.toJson(fromJson)).isEqualTo("{\"customArray\":[{\"data\":\"blub\"}]}");
   }
 
+  @Test public void serializesOnlyNonEmptyByteArray() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\n"
+        +   "\"byteArray\": [1]\n"
+        + "}");
+    assertThat(fromJson.byteArray).containsExactly((byte) 1);
+
+    fromJson.byteArray = new byte[0];
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+
+    fromJson.byteArray = new byte[] { 5 };
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"byteArray\":[5]}");
+  }
+
+  @Test public void serializesOnlyNonEmptyCharArray() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\n"
+        +   "\"charArray\": [\"A\"]\n"
+        + "}");
+    assertThat(fromJson.charArray).containsExactly((char) 65);
+
+    fromJson.charArray = new char[0];
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+
+    fromJson.charArray = new char[] { 65 };
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"charArray\":[\"A\"]}");
+  }
+
+  @Test public void serializesOnlyNonEmptyShortArray() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\n"
+        +   "\"shortArray\": [1]\n"
+        + "}");
+    assertThat(fromJson.shortArray).containsExactly((short) 1);
+
+    fromJson.shortArray = new short[0];
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+
+    fromJson.shortArray = new short[] { 5 };
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"shortArray\":[5]}");
+  }
+
   @Test public void serializesOnlyNonEmptyIntArray() throws Exception {
     JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
 
@@ -66,6 +111,66 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
 
     fromJson.intArray = new int[] { 5 };
     assertThat(adapter.toJson(fromJson)).isEqualTo("{\"intArray\":[5]}");
+  }
+
+  @Test public void serializesOnlyNonEmptyLongArray() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\n"
+        +   "\"longArray\": [1]\n"
+        + "}");
+    assertThat(fromJson.longArray).containsExactly(1L);
+
+    fromJson.longArray = new long[0];
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+
+    fromJson.longArray = new long[] { 5L };
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"longArray\":[5]}");
+  }
+
+  @Test public void serializesOnlyNonEmptyFloatArray() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\n"
+        +   "\"floatArray\": [1.0]\n"
+        + "}");
+    assertThat(fromJson.floatArray).containsExactly(1.f);
+
+    fromJson.floatArray = new float[0];
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+
+    fromJson.floatArray = new float[] { 5f };
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"floatArray\":[5.0]}");
+  }
+
+  @Test public void serializesOnlyNonEmptyDoubleArray() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\n"
+        +   "\"doubleArray\": [1.0]\n"
+        + "}");
+    assertThat(fromJson.doubleArray).containsExactly(1.f);
+
+    fromJson.doubleArray = new double[0];
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+
+    fromJson.doubleArray = new double[] { 5f };
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"doubleArray\":[5.0]}");
+  }
+
+  @Test public void serializesOnlyNonEmptyBooleanArray() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\n"
+        +   "\"booleanArray\": [false]\n"
+        + "}");
+    assertThat(fromJson.booleanArray).containsExactly(false);
+
+    fromJson.booleanArray = new boolean[0];
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+
+    fromJson.booleanArray = new boolean[] { false };
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"booleanArray\":[false]}");
   }
 
   @Test public void serializesOnlyNonEmptyStringArray() throws Exception {
@@ -129,7 +234,14 @@ public final class SerializeOnlyNonEmptyJsonAdapterTest {
 
   static class Data1 {
     @SerializeOnlyNonEmpty CustomType[] customArray;
+    @SerializeOnlyNonEmpty byte[] byteArray;
+    @SerializeOnlyNonEmpty char[] charArray;
+    @SerializeOnlyNonEmpty short[] shortArray;
     @SerializeOnlyNonEmpty int[] intArray;
+    @SerializeOnlyNonEmpty long[] longArray;
+    @SerializeOnlyNonEmpty float[] floatArray;
+    @SerializeOnlyNonEmpty double[] doubleArray;
+    @SerializeOnlyNonEmpty boolean[] booleanArray;
     @SerializeOnlyNonEmpty String[] stringArray;
     @SerializeOnlyNonEmpty Collection<String> collection;
     @SerializeOnlyNonEmpty Map<String, String> map;

--- a/src/unitTest/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapterTest.java
+++ b/src/unitTest/java/com/serjltt/moshi/adapters/SerializeOnlyNonEmptyJsonAdapterTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2016 Serj Lotutovici
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.serjltt.moshi.adapters;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class SerializeOnlyNonEmptyJsonAdapterTest {
+  // Lazy adapters work only within the context of moshi.
+  private final Moshi moshi = new Moshi.Builder()
+      .add(SerializeOnlyNonEmptyJsonAdapter.FACTORY)
+      .add(new Custom.CustomAdapter()) // We need to check that other annotations are not lost.
+      .build();
+
+  @Test public void serializesOnlyNonEmptyCustomArray() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\n"
+        +   "\"customArray\": [{"
+        +     "\"data\":\"blub\""
+        +   "}]\n"
+        + "}");
+    assertThat(fromJson.customArray).isNotNull().hasSize(1);
+    assertThat(fromJson.customArray[0].data).isEqualTo("blub");
+
+    fromJson.customArray = new CustomType[0];
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+
+    fromJson.customArray = new CustomType[] { new CustomType("blub") };
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"customArray\":[{\"data\":\"blub\"}]}");
+  }
+
+  @Test public void serializesOnlyNonEmptyIntArray() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\n"
+        +   "\"intArray\": [1]\n"
+        + "}");
+    assertThat(fromJson.intArray).containsExactly(1);
+
+    fromJson.intArray = new int[0];
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+
+    fromJson.intArray = new int[] { 5 };
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"intArray\":[5]}");
+  }
+
+  @Test public void serializesOnlyNonEmptyStringArray() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\n"
+        +   "\"stringArray\": [\"blub\"]\n"
+        + "}");
+    assertThat(fromJson.stringArray).containsExactly("blub");
+
+    fromJson.stringArray = new String[0];
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+
+    fromJson.stringArray = new String[] { "blub" };
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"stringArray\":[\"blub\"]}");
+  }
+
+  @Test public void serializesOnlyNonEmptyCollection() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\n"
+        +   "\"collection\": [\"blub\"]\n"
+        + "}");
+    assertThat(fromJson.collection).containsExactly("blub");
+
+    fromJson.collection = new ArrayList<>(0);
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+
+    fromJson.collection.add("blub");
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"collection\":[\"blub\"]}");
+  }
+
+  @Test public void serializesOnlyNonEmptyMap() throws Exception {
+    JsonAdapter<Data1> adapter = moshi.adapter(Data1.class);
+
+    Data1 fromJson = adapter.fromJson("{\n"
+        +   "\"map\": {"
+        +     "\"email\":\"blub\"\n"
+        +   "}\n"
+        + "}");
+    assertThat(fromJson.map).containsEntry("email", "blub");
+
+    fromJson.map = new HashMap<>();
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{}");
+
+    fromJson.map.put("email", "blub");
+    assertThat(adapter.toJson(fromJson)).isEqualTo("{\"map\":{\"email\":\"blub\"}}");
+  }
+
+  @Test public void toStringReflectsInnerAdapter() throws Exception {
+    JsonAdapter<String> adapter = moshi.adapter(String[].class, Collections.singleton(
+        new SerializeOnlyNonEmpty() {
+          @Override public Class<? extends Annotation> annotationType() {
+            return SerializeOnlyNonEmpty.class;
+          }
+        }));
+
+    assertThat(adapter.toString())
+        .isEqualTo("JsonAdapter(String[]).serializeOnlyNonEmpty()");
+  }
+
+  static class Data1 {
+    @SerializeOnlyNonEmpty CustomType[] customArray;
+    @SerializeOnlyNonEmpty int[] intArray;
+    @SerializeOnlyNonEmpty String[] stringArray;
+    @SerializeOnlyNonEmpty Collection<String> collection;
+    @SerializeOnlyNonEmpty Map<String, String> map;
+  }
+
+  static class CustomType {
+    final String data;
+
+    CustomType(final String data) {
+      this.data = data;
+    }
+  }
+}


### PR DESCRIPTION
Still WIP:

- [X] what should we do about primitive arrays? extend instance of check?
- [X] toString still fails

Do you have any better idea than using `instanceof`?

There is `Class<?>.isArray()` but AFAIK not a way to see whether it's empty or not.