### PR TITLE
Make WrappedJsonAdapter more strict.

### DIFF
--- a/src/integrationTest/java/com/serjltt/moshi/adapters/Data.java
+++ b/src/integrationTest/java/com/serjltt/moshi/adapters/Data.java
@@ -32,7 +32,7 @@ abstract class Data {
    * The name of the method will be taken as the first key, then the path provided with the
    * annotation.
    */
-  @Wrapped({"1"}) abstract Meta meta();
+  @Wrapped(path = {"1"}) abstract Meta meta();
 
   static class Meta {
     String value1;

--- a/src/integrationTest/java/com/serjltt/moshi/adapters/LazyAdaptersRetrofitTest.java
+++ b/src/integrationTest/java/com/serjltt/moshi/adapters/LazyAdaptersRetrofitTest.java
@@ -129,12 +129,12 @@ public final class LazyAdaptersRetrofitTest {
   private interface Service {
     /** Helps to test the unwrap adapter. */
     @GET("/")
-    @Wrapped({"one", "two"}) Call<String> unwrap();
+    @Wrapped(path = {"one", "two"}) Call<String> unwrap();
 
     @GET("/")
-    @Wrapped({"one", "two"}) Call<Nested> unwrapNested();
+    @Wrapped(path = {"one", "two"}) Call<Nested> unwrapNested();
 
-    @POST("/") Call<ResponseBody> wrappedPost(@Body @Wrapped({"1", "2"}) String value);
+    @POST("/") Call<ResponseBody> wrappedPost(@Body @Wrapped(path = {"1", "2"}) String value);
 
     /** Helps to test the first element json adapter. */
     @GET("/")
@@ -142,7 +142,7 @@ public final class LazyAdaptersRetrofitTest {
 
     /** Helps to test the first element json adapter. */
     @GET("/")
-    @Wrapped({"one", "two"})
+    @Wrapped(path = {"one", "two"})
     @FirstElement Call<String> unwrapFirstElement();
 
     @GET("/")
@@ -150,8 +150,8 @@ public final class LazyAdaptersRetrofitTest {
   }
 
   static class Nested {
-    @Json(name = "item") @Wrapped("foo") String foo;
-    @Json(name = "item2") @Wrapped("bar") int bar;
+    @Json(name = "item") @Wrapped(path = "foo") String foo;
+    @Json(name = "item2") @Wrapped(path = "bar") int bar;
     int foobar;
   }
 }

--- a/src/main/java/com/serjltt/moshi/adapters/Wrapped.java
+++ b/src/main/java/com/serjltt/moshi/adapters/Wrapped.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Arrays;
 
 /**
  * Indicates that the annotated type/field should be unwrapped by the {@linkplain
@@ -66,20 +67,20 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 public @interface Wrapped {
-  /** The path to the wrapped json value. */
-  String[] value();
+  /** The path to the wrapped json path. */
+  String[] path();
 
   /**
    * Indicates if the adapter should fail when the json object was not found at the indicated path.
-   * Default {@code false}.
+   * Default {@code true}.
    */
-  boolean failOnNotFound() default false;
+  boolean failOnNotFound() default true;
 
   /** Allows to easily create a new instance of {@link Wrapped} annotation. */
   final class Factory {
     /** Create a new instance of {@link Wrapped} with the specified JSON path. */
     public static Wrapped create(final String... path) {
-      return create(false, path);
+      return create(true, path);
     }
 
     /** Create a new instance of {@link Wrapped} with the specified JSON path. */
@@ -89,12 +90,34 @@ public @interface Wrapped {
           return Wrapped.class;
         }
 
-        @Override public String[] value() {
+        @Override public String[] path() {
           return path;
         }
 
         @Override public boolean failOnNotFound() {
           return failOnNotFound;
+        }
+
+        @Override public int hashCode() {
+          int result = Arrays.hashCode(path);
+          result = 43 * result + (failOnNotFound ? 1 : 0);
+          return result;
+        }
+
+        @Override public boolean equals(Object obj) {
+          if (this == obj) return true;
+          if (obj == null || getClass() != obj.getClass()) return false;
+
+          Wrapped wrapped = (Wrapped) obj;
+          return Arrays.equals(path, wrapped.path())
+              && failOnNotFound == wrapped.failOnNotFound();
+        }
+
+        @Override public String toString() {
+          return "Wrapped("
+              + "path=" + Arrays.asList(path)
+              + ", failOnNotFound=" + failOnNotFound
+              + ")";
         }
       };
     }


### PR DESCRIPTION
* Rename `Wrapped.value()` to `Wrapped.path()`
* Make `Wrapped.failOnNotFound()` `true` by default
* Remove null safety, make the adapter rely on the user to indicate that.