### PR TITLE
Introduce `@Transient` annotation and it's respective adapter.

### DIFF
--- a/src/integrationTest/java/com/serjltt/moshi/adapters/TransientAutoValueTest.java
+++ b/src/integrationTest/java/com/serjltt/moshi/adapters/TransientAutoValueTest.java
@@ -1,0 +1,53 @@
+package com.serjltt.moshi.adapters;
+
+import com.google.auto.value.AutoValue;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TransientAutoValueTest {
+  private final Moshi moshi = new Moshi.Builder()
+      .add(Transient.ADAPTER_FACTORY)
+      .add(DataFactories.create())
+      .build();
+
+  @Test public void serialize() {
+    final String json = AutoValueClass.jsonAdapter(moshi)
+        .toJson(new AutoValue_TransientAutoValueTest_AutoValueClass(1, 2));
+    assertThat(json).isEqualTo("{\"foo\":1}");
+  }
+
+  @Test public void deserialize() throws IOException {
+    final AutoValueClass autoValueClass =
+        AutoValueClass.jsonAdapter(moshi).fromJson("{\"foo\": 1,\"bar\": 2}");
+
+    assertThat(autoValueClass.foo()).isEqualTo(1);
+    assertThat(autoValueClass.bar()).isNull();
+  }
+
+  @Test public void toStringReflectsInnerAdapter() throws Exception {
+    JsonAdapter<String> adapter =
+        moshi.adapter(String.class, Collections.singleton(new SerializeOnly() {
+          @Override public Class<? extends Annotation> annotationType() {
+            return Transient.class;
+          }
+        }));
+
+    assertThat(adapter.toString()).isEqualTo("JsonAdapter(String).nullSafe().transient()");
+  }
+
+  @AutoValue abstract static class AutoValueClass {
+    public static JsonAdapter<AutoValueClass> jsonAdapter(Moshi moshi) {
+      return new AutoValue_TransientAutoValueTest_AutoValueClass.MoshiJsonAdapter(moshi);
+    }
+
+    abstract Integer foo();
+
+    @Transient @Nullable abstract Integer bar();
+  }
+}

--- a/src/main/java/com/serjltt/moshi/adapters/FallbackOnNullJsonAdapter.java
+++ b/src/main/java/com/serjltt/moshi/adapters/FallbackOnNullJsonAdapter.java
@@ -41,12 +41,12 @@ final class FallbackOnNullJsonAdapter<T> extends JsonAdapter<T> {
     PRIMITIVE_CLASSES.add(short.class);
   }
 
-  final JsonAdapter<T> dalegate;
+  final JsonAdapter<T> delegate;
   final T fallback;
   final String fallbackType;
 
   FallbackOnNullJsonAdapter(JsonAdapter<T> delegate, T fallback, String fallbackType) {
-    this.dalegate = delegate;
+    this.delegate = delegate;
     this.fallback = fallback;
     this.fallbackType = fallbackType;
   }
@@ -56,14 +56,14 @@ final class FallbackOnNullJsonAdapter<T> extends JsonAdapter<T> {
       reader.nextNull(); // We need to consume the value.
       return fallback;
     }
-    return dalegate.fromJson(reader);
+    return delegate.fromJson(reader);
   }
 
   @Override public void toJson(JsonWriter writer, T value) throws IOException {
-    dalegate.toJson(writer, value);
+    delegate.toJson(writer, value);
   }
 
   @Override public String toString() {
-    return dalegate + ".fallbackOnNull(" + fallbackType + '=' + fallback + ')';
+    return delegate + ".fallbackOnNull(" + fallbackType + '=' + fallback + ')';
   }
 }

--- a/src/main/java/com/serjltt/moshi/adapters/Transient.java
+++ b/src/main/java/com/serjltt/moshi/adapters/Transient.java
@@ -1,0 +1,44 @@
+package com.serjltt.moshi.adapters;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonQualifier;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+/**
+ * Indicates that the annotated method is transient.
+ *
+ * <p>To leverage from {@link Transient} {@link Transient#ADAPTER_FACTORY} must be added
+ * to your {@linkplain Moshi Moshi instance}:
+ *
+ * <pre><code>
+ *   Moshi moshi = new Moshi.Builder()
+ *      .add(Transient.ADAPTER_FACTORY)
+ *      .build();
+ * </code></pre>
+ */
+@Documented
+@JsonQualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD })
+public @interface Transient {
+  /** Builds an adapter that can process a type annotated with {@link Transient}. */
+  JsonAdapter.Factory ADAPTER_FACTORY = new JsonAdapter.Factory() {
+    @Override public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations,
+        Moshi moshi) {
+      Set<? extends Annotation> nextAnnotations =
+          Types.nextAnnotations(annotations, Transient.class);
+      if (nextAnnotations == null) return null;
+
+      return new TransientJsonAdapter<>(moshi.adapter(type, nextAnnotations), false, false);
+    }
+  };
+}


### PR DESCRIPTION
* The annotations targets only methods, and is presumed to be used
with auto-value-moshi.

Closes #43 