### PR TITLE
Forces WrappedJsonAdapter to re-throw all exceptions.

### DIFF
--- a/src/main/java/com/serjltt/moshi/adapters/WrappedJsonAdapter.java
+++ b/src/main/java/com/serjltt/moshi/adapters/WrappedJsonAdapter.java
@@ -58,7 +58,7 @@ final class WrappedJsonAdapter<T> extends JsonAdapter<T> {
       return adapter.fromJson(reader);
     } else {
       reader.beginObject();
-      IOException caughtException = null;
+      Exception caughtException = null;
       try {
         String root = path[index];
         while (reader.hasNext()) {
@@ -79,13 +79,19 @@ final class WrappedJsonAdapter<T> extends JsonAdapter<T> {
             reader.skipValue();
           }
         }
-      } catch (IOException e) {
+      } catch (Exception e) {
         caughtException = e;
       } finally {
         // If the try block throw an exception, rethrow it up the stack.
-        if (caughtException != null) {
+        if (caughtException instanceof IOException) {
           //noinspection ThrowFromFinallyBlock
-          throw caughtException;
+          throw (IOException) caughtException;
+        } else if (caughtException instanceof JsonDataException) {
+          //noinspection ThrowFromFinallyBlock
+          throw (JsonDataException) caughtException;
+        } else if (caughtException != null) {
+          //noinspection ThrowFromFinallyBlock
+          throw new AssertionError(caughtException);
         }
         // If the json has an additional key, that was not red, we ignore it.
         while (reader.hasNext()) {


### PR DESCRIPTION
* All IOExceptions and JsonDataExceptions will be re-thrown.
* Other types of exceptions will be wrapped in an AssertionError.

I've received a bug report where the adapter was failing later on in the `finally` bock. I assume this has to do with the fact that `JsonDataExpection` expends form `RuntimeException`, thus the error was not propagated properly. Hopefully, this ugly piece of code fixes it.