### PR TITLE
Delegate @Wrapped to custom annotation

### DIFF
--- a/src/main/java/com/serjltt/moshi/adapters/ElementAt.java
+++ b/src/main/java/com/serjltt/moshi/adapters/ElementAt.java
@@ -70,7 +70,7 @@ import static com.serjltt.moshi.adapters.Util.nextAnnotations;
 @Documented
 @JsonQualifier
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD, ElementType.METHOD })
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 public @interface ElementAt {
   /**
    * Represents the index location at which the element will be expected to be.

--- a/src/main/java/com/serjltt/moshi/adapters/FallbackOnNull.java
+++ b/src/main/java/com/serjltt/moshi/adapters/FallbackOnNull.java
@@ -48,7 +48,7 @@ import static com.serjltt.moshi.adapters.Util.nextAnnotations;
 @Documented
 @JsonQualifier
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD, ElementType.METHOD })
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 public @interface FallbackOnNull {
   /** Fallback value for {@code boolean} primitives. Default: {@code false}. */
   boolean fallbackBoolean() default false;

--- a/src/main/java/com/serjltt/moshi/adapters/Util.java
+++ b/src/main/java/com/serjltt/moshi/adapters/Util.java
@@ -44,6 +44,22 @@ final class Util {
         //noinspection unchecked Protected by the if statment.
         return new Pair<>((A) annotation, Collections.unmodifiableSet(delegateAnnotations));
       }
+      A delegate = findDelegatedAnnotation(annotation, jsonQualifier);
+      if (delegate != null) {
+        Set<? extends Annotation> delegateAnnotations = new LinkedHashSet<>(annotations);
+        delegateAnnotations.remove(annotation);
+        return new Pair<>(delegate, Collections.unmodifiableSet(delegateAnnotations));
+      }
+    }
+    return null;
+  }
+
+  private static <A extends Annotation> A findDelegatedAnnotation(Annotation annotation, Class<A> jsonQualifier) {
+    for (Annotation delegatedAnnotation : annotation.annotationType().getAnnotations()) {
+      if (jsonQualifier.equals(delegatedAnnotation.annotationType())) {
+        //noinspection unchecked
+        return (A) delegatedAnnotation;
+      }
     }
     return null;
   }

--- a/src/main/java/com/serjltt/moshi/adapters/Util.java
+++ b/src/main/java/com/serjltt/moshi/adapters/Util.java
@@ -54,7 +54,8 @@ final class Util {
     return null;
   }
 
-  private static <A extends Annotation> A findDelegatedAnnotation(Annotation annotation, Class<A> jsonQualifier) {
+  private static <A extends Annotation> A findDelegatedAnnotation(
+    Annotation annotation, Class<A> jsonQualifier) {
     for (Annotation delegatedAnnotation : annotation.annotationType().getAnnotations()) {
       if (jsonQualifier.equals(delegatedAnnotation.annotationType())) {
         //noinspection unchecked

--- a/src/main/java/com/serjltt/moshi/adapters/Wrapped.java
+++ b/src/main/java/com/serjltt/moshi/adapters/Wrapped.java
@@ -68,7 +68,7 @@ import static com.serjltt.moshi.adapters.Util.nextAnnotations;
 @Documented
 @JsonQualifier
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 public @interface Wrapped {
   /** The path to the wrapped json path. */
   String[] path();

--- a/src/main/java/com/serjltt/moshi/adapters/Wrapped.java
+++ b/src/main/java/com/serjltt/moshi/adapters/Wrapped.java
@@ -68,7 +68,12 @@ import static com.serjltt.moshi.adapters.Util.nextAnnotations;
 @Documented
 @JsonQualifier
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+@Target({
+  ElementType.FIELD,
+  ElementType.METHOD,
+  ElementType.PARAMETER,
+  ElementType.ANNOTATION_TYPE
+})
 public @interface Wrapped {
   /** The path to the wrapped json path. */
   String[] path();

--- a/src/unitTest/java/com/serjltt/moshi/adapters/WrappedJsonAdapterTest.java
+++ b/src/unitTest/java/com/serjltt/moshi/adapters/WrappedJsonAdapterTest.java
@@ -377,7 +377,7 @@ public final class WrappedJsonAdapterTest {
   @Wrapped(path = "1")
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
-  @interface WrappedDelegate {}
+  @interface WrappedDelegate { }
 
   /** String adapter, that will throw on read and write. */
   private static final class ThrowingAdapter {


### PR DESCRIPTION
I have a legacy API that wraps all responses in a specific JSON envelope. To avoid having to repeat `@Wrapped(path = ["deep", "inside", "the", "structure"])` over and over again and also because it is not possible to replace the constant path array by a non-constant, final array in Java / Kotlin (like so `@Wrapped(path = CUSTOM_PATH)`, I decided to give your adapters support for creating custom annotations:

    @JsonQualifier
    @Wrapped(path = ["deep", "inside", "the", "structure"])
    @Retention(RetentionPolicy.RUNTIME)
    @Target([ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER])
    annotation UnwrapCrap

On the way I figured other annotations - at least those that still used the `Util.nextAnnotations(...)` method and not the one from Moshi - could benefit from that as well, so I added support and tests.